### PR TITLE
Fix: Tag banner not showing up on category listing

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,4 +1,3 @@
-
 <script type="text/discourse-plugin" version="0.8">
   const container = Discourse.__container__;
   const { h } = require('virtual-dom');
@@ -47,7 +46,7 @@
              );
 
           } else {
-            document.querySelector("body").classList.remove("tag-banner")
+            document.querySelector("body").classList.remove("tag-banner");
           }
         } elseif(/^\/tag\//.test(path)) {
             var controller = container.lookup('controller:tag');
@@ -85,7 +84,7 @@
              );
 
           } else {
-            document.querySelector("body").classList.remove("tag-banner")
+            document.querySelector("body").classList.remove("tag-banner");
           }
         }
       }

--- a/common/header.html
+++ b/common/header.html
@@ -10,7 +10,7 @@
 
           const path = window.location.pathname;
 
-          if(/^\/tag\//.test(path)) {
+          if(/^\/tag\//.test(path) || /^\/tags\//.test(path)) {
             const controller = container.lookup('controller:tag');
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 

--- a/common/header.html
+++ b/common/header.html
@@ -48,6 +48,44 @@
           } else {
             document.querySelector("body").classList.remove("tag-banner");
           }
+        } else if(/^\/tag\//.test(path)) {
+            var controller = container.lookup('controller:tag');
+            const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
+
+            let tag;
+            let additionalTags;
+
+            tag = controller.get("target.currentRoute.params.tag_id");
+            additionalTags = controller.get("target.currentRoute.params.additional_tags");
+
+            if(!hideMobile && tag != "none") {
+
+            document.querySelector("body").classList.add("tag-banner")
+
+              if (additionalTags) {
+                var tagList = additionalTags.split("/");
+                var additionalTagNames = h('span', " & " + tagList.join(' & '));
+                var additionalNaming = tagList.map(function(e) {return 'tag-banner-' + e});
+                var additionalClasses = additionalNaming.join('.');
+              } else {
+                var additionalClasses = "single-tag";
+              }
+
+              return h('div.tag-title-header'
+                + " .tag-banner-"
+                + tag
+                + " ."
+                + additionalClasses, h('div.tag-title-contents', [
+                  h('h1',  [
+                    h('span', tag),
+                    additionalTagNames
+                  ]),
+                ]),
+             );
+
+          } else {
+            document.querySelector("body").classList.remove("tag-banner");
+          }
         }
       }
   }),

--- a/common/header.html
+++ b/common/header.html
@@ -1,5 +1,5 @@
-type="text/discourse-plugin"
-<script  version="0.8">
+
+<script type="text/discourse-plugin" version="0.8">
   const container = Discourse.__container__;
   const { h } = require('virtual-dom');
   const { iconNode } = require("discourse-common/lib/icon-library");

--- a/common/header.html
+++ b/common/header.html
@@ -11,9 +11,9 @@
           const path = window.location.pathname;
 
           if(/^\/tags\//.test(path)) {
-              const controller = container.lookup('controller:tags');
+              var controller = container.lookup('controller:tags');
           } else if (/^\/tag\//.test(path)) {
-              const controller = container.lookup('controller:tag');
+              var controller = container.lookup('controller:tag');
           }
 
           if(/^\/tags\//.test(path) || /^\/tag\//.test(path)) {

--- a/common/header.html
+++ b/common/header.html
@@ -11,45 +11,12 @@
           const path = window.location.pathname;
 
           if(/^\/tags\//.test(path)) {
-            var controller = container.lookup('controller:tags');
-            const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
-
-            let tag;
-            let additionalTags;
-
-            tag = controller.get("target.currentRoute.params.tag_id");
-            additionalTags = controller.get("target.currentRoute.params.additional_tags");
-
-            if(!hideMobile && tag != "none") {
-
-            document.querySelector("body").classList.add("tag-banner")
-
-              if (additionalTags) {
-                var tagList = additionalTags.split("/");
-                var additionalTagNames = h('span', " & " + tagList.join(' & '));
-                var additionalNaming = tagList.map(function(e) {return 'tag-banner-' + e});
-                var additionalClasses = additionalNaming.join('.');
-              } else {
-                var additionalClasses = "single-tag";
-              }
-
-              return h('div.tag-title-header'
-                + " .tag-banner-"
-                + tag
-                + " ."
-                + additionalClasses, h('div.tag-title-contents', [
-                  h('h1',  [
-                    h('span', tag),
-                    additionalTagNames
-                  ]),
-                ]),
-             );
-
-          } else {
-            document.querySelector("body").classList.remove("tag-banner");
+              const controller = container.lookup('controller:tags');
+          } else if (/^\/tag\//.test(path)) {
+              const controller = container.lookup('controller:tag');
           }
-        } else if(/^\/tag\//.test(path)) {
-            var controller = container.lookup('controller:tag');
+
+          if(/^\/tags\//.test(path) || /^\/tag\//.test(path)) {
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 
             let tag;

--- a/common/header.html
+++ b/common/header.html
@@ -10,8 +10,9 @@
 
           const path = window.location.pathname;
 
-          if(/^\/tags\//.test(path)) {
-            const controller = container.lookup('controller:tags');
+          if(/^\/tag\//.test(path) || /^\/tags\//.test(path)) {
+            if(/^\/tag\//.test(path)) const controller = container.lookup('controller:tag');
+            if(/^\/tags\//.test(path)) const controller = container.lookup('controller:tags');
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 
             let tag;

--- a/common/header.html
+++ b/common/header.html
@@ -10,12 +10,8 @@
 
           const path = window.location.pathname;
 
-          if(/^\/tag\//.test(path) || /^\/tags\//.test(path)) {
-            if(/^\/tag\//.test(path)) {
-                var controller = container.lookup('controller:tag');
-            } else {
-                var controller = container.lookup('controller:tags');
-            }
+          if(/^\/tags\//.test(path)) {
+            var controller = container.lookup('controller:tags');
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 
             let tag;

--- a/common/header.html
+++ b/common/header.html
@@ -11,8 +11,7 @@
           const path = window.location.pathname;
 
           if(/^\/tag\//.test(path) || /^\/tags\//.test(path)) {
-            if(/^\/tag\//.test(path)) const controller = container.lookup('controller:tag');
-            if(/^\/tags\//.test(path)) const controller = container.lookup('controller:tags');
+            /^\/tag\//.test(path) ? const controller = container.lookup('controller:tag') : const controller = container.lookup('controller:tags');
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 
             let tag;

--- a/common/header.html
+++ b/common/header.html
@@ -48,44 +48,6 @@
           } else {
             document.querySelector("body").classList.remove("tag-banner");
           }
-        } elseif(/^\/tag\//.test(path)) {
-            var controller = container.lookup('controller:tag');
-            const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
-
-            let tag;
-            let additionalTags;
-
-            tag = controller.get("target.currentRoute.params.tag_id");
-            additionalTags = controller.get("target.currentRoute.params.additional_tags");
-
-            if(!hideMobile && tag != "none") {
-
-            document.querySelector("body").classList.add("tag-banner")
-
-              if (additionalTags) {
-                var tagList = additionalTags.split("/");
-                var additionalTagNames = h('span', " & " + tagList.join(' & '));
-                var additionalNaming = tagList.map(function(e) {return 'tag-banner-' + e});
-                var additionalClasses = additionalNaming.join('.');
-              } else {
-                var additionalClasses = "single-tag";
-              }
-
-              return h('div.tag-title-header'
-                + " .tag-banner-"
-                + tag
-                + " ."
-                + additionalClasses, h('div.tag-title-contents', [
-                  h('h1',  [
-                    h('span', tag),
-                    additionalTagNames
-                  ]),
-                ]),
-             );
-
-          } else {
-            document.querySelector("body").classList.remove("tag-banner");
-          }
         }
       }
   }),

--- a/common/header.html
+++ b/common/header.html
@@ -12,9 +12,9 @@
 
           if(/^\/tag\//.test(path) || /^\/tags\//.test(path)) {
             if(/^\/tag\//.test(path)) {
-                const controller = container.lookup('controller:tag');
+                var controller = container.lookup('controller:tag');
             } else {
-                const controller = container.lookup('controller:tags');
+                var controller = container.lookup('controller:tags');
             }
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 

--- a/common/header.html
+++ b/common/header.html
@@ -1,4 +1,5 @@
-<script type="text/discourse-plugin" version="0.8">
+type="text/discourse-plugin"
+<script  version="0.8">
   const container = Discourse.__container__;
   const { h } = require('virtual-dom');
   const { iconNode } = require("discourse-common/lib/icon-library");
@@ -12,6 +13,44 @@
 
           if(/^\/tags\//.test(path)) {
             var controller = container.lookup('controller:tags');
+            const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
+
+            let tag;
+            let additionalTags;
+
+            tag = controller.get("target.currentRoute.params.tag_id");
+            additionalTags = controller.get("target.currentRoute.params.additional_tags");
+
+            if(!hideMobile && tag != "none") {
+
+            document.querySelector("body").classList.add("tag-banner")
+
+              if (additionalTags) {
+                var tagList = additionalTags.split("/");
+                var additionalTagNames = h('span', " & " + tagList.join(' & '));
+                var additionalNaming = tagList.map(function(e) {return 'tag-banner-' + e});
+                var additionalClasses = additionalNaming.join('.');
+              } else {
+                var additionalClasses = "single-tag";
+              }
+
+              return h('div.tag-title-header'
+                + " .tag-banner-"
+                + tag
+                + " ."
+                + additionalClasses, h('div.tag-title-contents', [
+                  h('h1',  [
+                    h('span', tag),
+                    additionalTagNames
+                  ]),
+                ]),
+             );
+
+          } else {
+            document.querySelector("body").classList.remove("tag-banner")
+          }
+        } elseif(/^\/tag\//.test(path)) {
+            var controller = container.lookup('controller:tag');
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 
             let tag;

--- a/common/header.html
+++ b/common/header.html
@@ -10,8 +10,8 @@
 
           const path = window.location.pathname;
 
-          if(/^\/tag\//.test(path) || /^\/tags\//.test(path)) {
-            const controller = container.lookup('controller:tag');
+          if(/^\/tags\//.test(path)) {
+            const controller = container.lookup('controller:tags');
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 
             let tag;

--- a/common/header.html
+++ b/common/header.html
@@ -11,7 +11,11 @@
           const path = window.location.pathname;
 
           if(/^\/tag\//.test(path) || /^\/tags\//.test(path)) {
-            /^\/tag\//.test(path) ? const controller = container.lookup('controller:tag') : const controller = container.lookup('controller:tags');
+            if(/^\/tag\//.test(path)) {
+                const controller = container.lookup('controller:tag');
+            } else {
+                const controller = container.lookup('controller:tags');
+            }
             const hideMobile = (!settings.show_on_mobile && this.site.mobileView) ? "true" : hideMobile;
 
             let tag;


### PR DESCRIPTION
Hello,

I have discovered a bug within this component. To sum it up if you open category and select tag the tag banner wont show because of different routes. If you click the tag and open the tag page (route starting with /tag/) you get the banner, while the categories have route starting with /tags/ and a different controller.

This PR also serves as a feature request to this comment:
https://meta.discourse.org/t/discourse-tag-banners/124240/14


**Please squash commits if you are going to merge...**

Thanks