### PR TITLE
FIX: ensure tag links do not have spaces

### DIFF
--- a/javascripts/discourse/components/discourse-tag-banners-text-only.hbs
+++ b/javascripts/discourse/components/discourse-tag-banners-text-only.hbs
@@ -4,7 +4,7 @@
       {{d-icon "tag"}}
     {{/if}}
   {{/if}}
-  {{discourse-tag @formattedTagName}}
+  {{discourse-tag @tag.name displayName=@formattedTagName}}
   {{#if @formattedAdditionalTagNames}}
     &amp;
     {{@formattedAdditionalTagNames}}

--- a/javascripts/discourse/components/discourse-tag-banners.hbs
+++ b/javascripts/discourse/components/discourse-tag-banners.hbs
@@ -10,6 +10,7 @@
         <DiscourseTagBannersTextOnly
           @formattedTagName={{this.formattedTagName}}
           @formattedAdditionalTagNames={{this.formattedAdditionalTagNames}}
+          @tag={{this.tag}}
         />
       {{else}}
         <DiscourseTagBannersPresentation


### PR DESCRIPTION
This relies on a core update: https://github.com/discourse/discourse/pull/21391

When integrating category banners with linked tags, a tag link gets appended to the respective category banner. However, when utilizing the `{{discourse-tag}}` function to create this tag link, coupled with the theme setting to eliminate hyphens or underscores for an aesthetically pleasing display, the tag links generated by `{{discourse-tag}}` would break. 

So the core update allows us to pass a `displayName` to `{{discourse-tag}}`, so the link can function correctly while the tag text displays differently. 