### PR TITLE
FIX: Allow HTML in tag banner descriptions to match core

### DIFF
--- a/javascripts/discourse/components/discourse-tag-banners-presentation.hbs
+++ b/javascripts/discourse/components/discourse-tag-banners-presentation.hbs
@@ -16,7 +16,7 @@
     {{#unless @isIntersection}}
       {{! hide descriptions on tag intersections}}
       {{#if (theme-setting "show_tag_description")}}
-        <p>{{@tag.description}}</p>
+        <p>{{html-safe @tag.description}}</p>
       {{/if}}
     {{/unless}}
   </div>


### PR DESCRIPTION
This is a neccessary update following https://github.com/discourse/discourse/pull/22994

**Before**

<img width="800" alt="Screenshot 2023-08-29 at 3 03 36 PM" src="https://github.com/discourse/discourse-tag-banners/assets/22733864/89ae0666-38e3-4825-85b6-1c81f0fa5d34">

**After**

<img width="800" alt="Screenshot 2023-08-29 at 3 03 01 PM" src="https://github.com/discourse/discourse-tag-banners/assets/22733864/33ee09e5-ccb7-40bf-ae32-fcfefe3f1f9a">
